### PR TITLE
Upgrade to ppxlib.0.14.0

### DIFF
--- a/ppx_stable.opam
+++ b/ppx_stable.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.14" & < "v0.15"}
   "dune"   {>= "2.0.0"}
-  "ppxlib" {>= "0.11.0"}
+  "ppxlib" {>= "0.14.0"}
 ]
 synopsis: "Stable types conversions generator"
 description: "

--- a/src/ppx_stable.ml
+++ b/src/ppx_stable.ml
@@ -88,7 +88,7 @@ let mk_lident ~loc str = Located.mk ~loc (Longident.Lident str)
 let mk_module ~loc ~name ~items =
   pstr_module
     ~loc
-    (module_binding ~loc ~name:(Located.mk ~loc name) ~expr:(pmod_structure ~loc items))
+    (module_binding ~loc ~name:(Located.mk ~loc (Some name)) ~expr:(pmod_structure ~loc items))
 ;;
 
 (* fun ~name:name -> exp *)


### PR DESCRIPTION
The next release of ppxlib will use the 4.10 AST internally. This PR makes ppx_stable compatible with this new version. Probably worth waiting for the new release before merging this!